### PR TITLE
Update README.md

### DIFF
--- a/packages/koa-shopify-auth/README.md
+++ b/packages/koa-shopify-auth/README.md
@@ -40,6 +40,8 @@ app.use(
     secret: SHOPIFY_SECRET,
     // scopes to request on the merchants store
     scopes: ['write_orders, write_products'],
+    // set access mode, default is 'online'
+    accessMode: 'offline',
     // callback for when auth is completed
     afterAuth(ctx) {
       const {shop, accessToken} = ctx.session;


### PR DESCRIPTION
Add access mode config related information.

This is something that needs to be documented, I've been struggling for like 3 hours not being able to figure out why my access token stopped working as soon as I logged out from admin. Turns out online access mode is set by default, and you can actually change it by using the correct parameter.